### PR TITLE
Fixes compiler errors for unknown instance method "indexPath"

### DIFF
--- a/ASHSpringyCollectionView/ASHSpringyCollectionViewFlowLayout.m
+++ b/ASHSpringyCollectionView/ASHSpringyCollectionViewFlowLayout.m
@@ -52,13 +52,20 @@
     
     // Step 1: Remove any behaviours that are no longer visible.
     NSArray *noLongerVisibleBehaviours = [self.dynamicAnimator.behaviors filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(UIAttachmentBehavior *behaviour, NSDictionary *bindings) {
-        BOOL currentlyVisible = [itemsIndexPathsInVisibleRectSet member:[[[behaviour items] firstObject] indexPath]] != nil;
+        id <UIDynamicItem> item = [[behaviour items] firstObject];
+        BOOL currentlyVisible = NO;
+        if ([item isKindOfClass:[UICollectionViewLayoutAttributes class]]) {
+            currentlyVisible = [itemsIndexPathsInVisibleRectSet member:[(UICollectionViewLayoutAttributes<UIDynamicItem> *)item indexPath]] != nil;
+        }
         return !currentlyVisible;
     }]];
     
     [noLongerVisibleBehaviours enumerateObjectsUsingBlock:^(id obj, NSUInteger index, BOOL *stop) {
         [self.dynamicAnimator removeBehavior:obj];
-        [self.visibleIndexPathsSet removeObject:[[[obj items] firstObject] indexPath]];
+        id <UIDynamicItem>item = [[obj items] firstObject];
+        if ([item isKindOfClass:[UICollectionViewLayoutAttributes class]]) {
+            [self.visibleIndexPathsSet removeObject:[(UICollectionViewLayoutAttributes<UIDynamicItem> *)item indexPath]];
+        }
     }];
     
     // Step 2: Add any newly visible behaviours.


### PR DESCRIPTION
Just checked this project out on Xcode 7.3, and, a fresh build gives me two compiler errors:

```
    ASHSpringyCollectionViewFlowLayout.m:55:106: error: no known instance method for selector 'indexPath'
            BOOL currentlyVisible = [itemsIndexPathsInVisibleRectSet member:[[[behaviour items] firstObject] indexPath]] != nil;  
```
and
```
    ASHSpringyCollectionViewFlowLayout.m:61:76: error: no known instance method for selector 'indexPath'
            [self.visibleIndexPathsSet removeObject:[[[obj items] firstObject] indexPath]];
```

This branch declares the `id<UIDynamicItem>` object, and does some basic guarding in case the object isn't a `UICollectionViewLayoutAttributes` object, though in this project it always is.  Compiles now and example matches gif on the README.